### PR TITLE
Make the header generation public.

### DIFF
--- a/src/Jeskew/Guzzle/Plugin/Hawk.php
+++ b/src/Jeskew/Guzzle/Plugin/Hawk.php
@@ -47,7 +47,7 @@ class Hawk implements SubscriberInterface
         );
     }
 
-    private function generateHawkRequest(
+    public function generateHawkRequest(
         $key,
         $secret,
         $url,


### PR DESCRIPTION
Just changing the Hawk Request generation function to public so it can be used for an outside signer.
